### PR TITLE
Dates and apostrophes

### DIFF
--- a/spec/example_theme/index.html
+++ b/spec/example_theme/index.html
@@ -5,9 +5,8 @@
 <body>
 <ol data-id="page-list">
   <li data-id="page-list-item">
-    <p><strong>
       <a data-id="page-link" />
-    </strong></p>
+      <p data-id="published-at-str"></p>
     <hr />
   </li>
 </ol>

--- a/spec/example_theme/index.html
+++ b/spec/example_theme/index.html
@@ -1,4 +1,7 @@
 <html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
 <body>
 <ol data-id="page-list">
   <li data-id="page-list-item">

--- a/spec/example_theme/post.html
+++ b/spec/example_theme/post.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   </head>
   <body>
     <h1  data-id="title"></h1>

--- a/spec/pinaclj/core_spec.clj
+++ b/spec/pinaclj/core_spec.clj
@@ -20,11 +20,11 @@
 
 (def url-page
   {:path "pages/a-test-path.md"
-   :content "title: 3\nurl: /a/blog/page.html\npublished-at: 2014-10-31T13:05:00Z\n---\nContent"})
+   :content "title: Three\nurl: /a/blog/page.html\npublished-at: 2014-10-31T13:05:00Z\n---\nContent"})
 
 (def url-index-page
   {:path "pages/a-wordpress-style-path.md"
-   :content "title: 4\nurl: /a/blog/page/\npublished-at: 2014-10-31T14:05:00Z\n---\nContent"})
+   :content "title: Four\nurl: /a/blog/page/\npublished-at: 2014-10-31T14:05:00Z\n---\nContent"})
 
 (def quote-page
   {:path "pages/quote_test.md"
@@ -92,5 +92,5 @@
       (should-contain "Nested Title" (index-contents @fs)))
 
     (it "orders pages in reverse chronological order"
-      (should (re-find #"4.*3.*Test.*Nested" (index-contents @fs))))))
+      (should (re-find #"(?s)Four.*Three.*Test.*Nested" (index-contents @fs))))))
 

--- a/spec/pinaclj/core_spec.clj
+++ b/spec/pinaclj/core_spec.clj
@@ -26,11 +26,15 @@
   {:path "pages/a-wordpress-style-path.md"
    :content "title: 4\nurl: /a/blog/page/\npublished-at: 2014-10-31T14:05:00Z\n---\nContent"})
 
+(def quote-page
+  {:path "pages/quote_test.md"
+   :content "published-at: 2014-10-31T15:05:00Z\n---\n'"})
+
 (def published-pages
-  [nested-page simple-page url-page url-index-page])
+  [nested-page simple-page url-page url-index-page quote-page])
 
 (def all-pages
-  [nested-page simple-page draft-page url-page url-index-page])
+  [nested-page simple-page draft-page url-page url-index-page quote-page])
 
 (defn- compile-page [fs]
   (compile-all (files/resolve-path fs "pages")
@@ -72,7 +76,10 @@
       (should (files/exists? (files/resolve-path @fs "published/a/blog/page.html"))))
 
     (it "adds html extension if it isn't present"
-      (should (files/exists? (files/resolve-path @fs "published/a/blog/page/index.html")))))
+      (should (files/exists? (files/resolve-path @fs "published/a/blog/page/index.html"))))
+
+    (it "transforms quotes"
+      (should-contain "‘" (files/content (files/resolve-path @fs "published/quote_test.html")))))
 
   (describe "index page"
     (it "renders an index page"

--- a/spec/pinaclj/date_time_spec.clj
+++ b/spec/pinaclj/date_time_spec.clj
@@ -7,4 +7,7 @@
     (should= 2014 (.getYear (make 2014 12 14 21 30 00))))
 
   (it "converts to string and back"
-    (should= "2014-10-31T10:05:00Z" (to-str (from-str "2014-10-31T10:05:00Z")))))
+    (should= "2014-10-31T10:05:00Z" (to-str (from-str "2014-10-31T10:05:00Z"))))
+
+  (it "converts datetime to readable format"
+    (should= "5 February 2015", (to-readable-str (from-str "2015-02-05T10:05:00Z")))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -2,13 +2,13 @@
   (:require [speclj.core :refer :all]
             [pinaclj.quote-transform :refer :all]))
 
-(def noQuotes
+(def no-quotes
   "abc")
 
-(def singleQuotes
+(def single-quotes
   "'singlestart' 'singleend' let's")
 
-(def doubleQuotes
+(def double-quotes
   "\"doublestart\" \"doubleend\"")
 
 (def inside-html
@@ -26,47 +26,50 @@
 (def code-with-class
   "<p><code class=\"clojure\">''</code></p>")
 
-(describe "replace quotes"
-  (it "returns string with no quotes"
-    (should= noQuotes (convert noQuotes)))
+(describe "transforms"
+  (it "starting single quote to &lsquo;"
+    (should-contain "&lsquo;singlestart" (transform single-quotes)))
 
-  (it "converts starting single quote to &lsquo;"
-    (should-contain "&lsquo;singlestart" (convert singleQuotes)))
+  (it "inner single quote to &rsquo;"
+    (should-contain "singlestart&rsquo;" (transform single-quotes)))
 
-  (it "converts inner single quote to &rsquo;"
-    (should-contain "singlestart&rsquo;" (convert singleQuotes)))
+  (it "inner single quote to &lsquo;"
+    (should-contain "&lsquo;singleend" (transform single-quotes)))
 
-  (it "converts inner single quote to &lsquo;"
-    (should-contain "&lsquo;singleend" (convert singleQuotes)))
+  (it "ending single quote to &rsquo;"
+    (should-contain "singleend&rsquo;" (transform single-quotes)))
 
-  (it "converts ending single quote to &rsquo;"
-    (should-contain "singleend&rsquo;" (convert singleQuotes)))
+  (it "apostrophe to &rsquo;"
+    (should-contain "let&rsquo;s" (transform single-quotes)))
 
-  (it "converts apostrophe to &rsquo;"
-    (should-contain "let&rsquo;s" (convert singleQuotes)))
+  (it "starting double quote to &lsquo;"
+    (should-contain "&ldquo;doublestart" (transform double-quotes)))
 
-  (it "converts starting double quote to &lsquo;"
-    (should-contain "&ldquo;doublestart" (convert doubleQuotes)))
+  (it "inner double quote to &rsquo;"
+    (should-contain "doublestart&rdquo;" (transform double-quotes)))
 
-  (it "converts inner double quote to &rsquo;"
-    (should-contain "doublestart&rdquo;" (convert doubleQuotes)))
+  (it "inner double quote to &lsquo;"
+    (should-contain "&ldquo;doubleend" (transform double-quotes)))
 
-  (it "converts inner double quote to &lsquo;"
-    (should-contain "&ldquo;doubleend" (convert doubleQuotes)))
+  (it "ending double quote to &rsquo;"
+    (should-contain "doubleend&rdquo;" (transform double-quotes)))
 
-  (it "converts ending double quote to &rsquo;" (should-contain "doubleend&rdquo;" (convert doubleQuotes)))
-
-  (it "converts inside html"
-    (should= "<p>&lsquo;&rsquo;</p>" (convert inside-html)))
-
-  (it "does not convert inside code block"
-    (should= inside-code-block (convert inside-code-block)))
-
-  (it "does not convert attribute quotes"
-    (should= attributes (convert attributes)))
+  (it "inside html"
+    (should= "<p>&lsquo;&rsquo;</p>" (transform inside-html)))
 
   (it "quotes after punctuation"
-    (should-contain ".&rdquo;" (convert quote-sentence)))
+    (should-contain ".&rdquo;" (transform quote-sentence))))
 
-  (it "does not convert inside code element with class block"
-    (should= code-with-class (convert code-with-class))))
+(describe "does not transform"
+
+  (it "string with no quotes"
+    (should= no-quotes (transform no-quotes)))
+
+  (it "inside code element with class block"
+    (should= code-with-class (transform code-with-class)))
+
+  (it "inside code block"
+    (should= inside-code-block (transform inside-code-block)))
+
+  (it "attribute quotes"
+    (should= attributes (transform attributes))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -14,35 +14,53 @@
 (def insideHtml
   "<p>''</p>")
 
+(def insideCodeBlock
+  "<p><code>''\"\"</code></p>")
+
+(def attributes
+  "<img src=\"t'est\" />")
+
+(def quote-sentence
+  "\"This code is not clean, he said.\"")
+
 (describe "replace quotes"
   (it "returns string with no quotes"
-    (should= noQuotes (convert-quote-text noQuotes)))
+    (should= noQuotes (convert noQuotes)))
 
   (it "converts starting single quote to &lsquo;"
-    (should-contain "&lsquo;singlestart" (convert-quote-text singleQuotes)))
+    (should-contain "&lsquo;singlestart" (convert singleQuotes)))
 
   (it "converts inner single quote to &rsquo;"
-    (should-contain "singlestart&rsquo;" (convert-quote-text singleQuotes)))
+    (should-contain "singlestart&rsquo;" (convert singleQuotes)))
 
   (it "converts inner single quote to &lsquo;"
-    (should-contain "&lsquo;singleend" (convert-quote-text singleQuotes)))
+    (should-contain "&lsquo;singleend" (convert singleQuotes)))
 
   (it "converts ending single quote to &rsquo;"
-    (should-contain "singleend&rsquo;" (convert-quote-text singleQuotes)))
+    (should-contain "singleend&rsquo;" (convert singleQuotes)))
 
   (it "converts apostrophe to &rsquo;"
-    (should-contain "let&rsquo;s" (convert-quote-text singleQuotes)))
+    (should-contain "let&rsquo;s" (convert singleQuotes)))
 
   (it "converts starting double quote to &lsquo;"
-    (should-contain "&ldquo;doublestart" (convert-quote-text doubleQuotes)))
+    (should-contain "&ldquo;doublestart" (convert doubleQuotes)))
 
   (it "converts inner double quote to &rsquo;"
-    (should-contain "doublestart&rdquo;" (convert-quote-text doubleQuotes)))
+    (should-contain "doublestart&rdquo;" (convert doubleQuotes)))
 
   (it "converts inner double quote to &lsquo;"
-    (should-contain "&ldquo;doubleend" (convert-quote-text doubleQuotes)))
+    (should-contain "&ldquo;doubleend" (convert doubleQuotes)))
 
-  (it "converts ending double quote to &rsquo;" (should-contain "doubleend&rdquo;" (convert-quote-text doubleQuotes)))
+  (it "converts ending double quote to &rsquo;" (should-contain "doubleend&rdquo;" (convert doubleQuotes)))
 
   (it "converts inside html"
-    (should= "<p>&lsquo;&rsquo;</p>" (convert-quote-text insideHtml))))
+    (should= "<p>&lsquo;&rsquo;</p>" (convert insideHtml)))
+
+  (xit "does not convert inside code block"
+    (should= insideCodeBlock (convert insideCodeBlock)))
+
+  (xit "does not convert attribute quotes"
+    (should= attributes (convert attributes)))
+
+  (it "quotes after punctuation"
+    (should-contain ".&rdquo;" (convert quote-sentence))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -1,0 +1,48 @@
+(ns pinaclj.quote-transform-spec
+  (:require [speclj.core :refer :all]
+            [pinaclj.quote-transform :refer :all]))
+
+(def noQuotes
+  "abc")
+
+(def singleQuotes
+  "'singlestart' 'singleend' let's")
+
+(def doubleQuotes
+  "\"doublestart\" \"doubleend\"")
+
+(def insideHtml
+  "<p>''</p>")
+
+(describe "replace quotes"
+  (it "returns string with no quotes"
+    (should= noQuotes (convert-quote-text noQuotes)))
+
+  (it "converts starting single quote to &lsquo;"
+    (should-contain "&lsquo;singlestart" (convert-quote-text singleQuotes)))
+
+  (it "converts inner single quote to &rsquo;"
+    (should-contain "singlestart&rsquo;" (convert-quote-text singleQuotes)))
+
+  (it "converts inner single quote to &lsquo;"
+    (should-contain "&lsquo;singleend" (convert-quote-text singleQuotes)))
+
+  (it "converts ending single quote to &rsquo;"
+    (should-contain "singleend&rsquo;" (convert-quote-text singleQuotes)))
+
+  (it "converts apostrophe to &rsquo;"
+    (should-contain "let&rsquo;s" (convert-quote-text singleQuotes)))
+
+  (it "converts starting double quote to &lsquo;"
+    (should-contain "&ldquo;doublestart" (convert-quote-text doubleQuotes)))
+
+  (it "converts inner double quote to &rsquo;"
+    (should-contain "doublestart&rdquo;" (convert-quote-text doubleQuotes)))
+
+  (it "converts inner double quote to &lsquo;"
+    (should-contain "&ldquo;doubleend" (convert-quote-text doubleQuotes)))
+
+  (it "converts ending double quote to &rsquo;" (should-contain "doubleend&rdquo;" (convert-quote-text doubleQuotes)))
+
+  (it "converts inside html"
+    (should= "<p>&lsquo;&rsquo;</p>" (convert-quote-text insideHtml))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -56,10 +56,10 @@
   (it "converts inside html"
     (should= "<p>&lsquo;&rsquo;</p>" (convert insideHtml)))
 
-  (xit "does not convert inside code block"
+  (it "does not convert inside code block"
     (should= insideCodeBlock (convert insideCodeBlock)))
 
-  (xit "does not convert attribute quotes"
+  (it "does not convert attribute quotes"
     (should= attributes (convert attributes)))
 
   (it "quotes after punctuation"

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -11,10 +11,10 @@
 (def doubleQuotes
   "\"doublestart\" \"doubleend\"")
 
-(def insideHtml
+(def inside-html
   "<p>''</p>")
 
-(def insideCodeBlock
+(def inside-code-block
   "<p><code>''\"\"</code></p>")
 
 (def attributes
@@ -22,6 +22,9 @@
 
 (def quote-sentence
   "\"This code is not clean, he said.\"")
+
+(def code-with-class
+  "<p><code class=\"clojure\">''</code></p>")
 
 (describe "replace quotes"
   (it "returns string with no quotes"
@@ -54,13 +57,16 @@
   (it "converts ending double quote to &rsquo;" (should-contain "doubleend&rdquo;" (convert doubleQuotes)))
 
   (it "converts inside html"
-    (should= "<p>&lsquo;&rsquo;</p>" (convert insideHtml)))
+    (should= "<p>&lsquo;&rsquo;</p>" (convert inside-html)))
 
   (it "does not convert inside code block"
-    (should= insideCodeBlock (convert insideCodeBlock)))
+    (should= inside-code-block (convert inside-code-block)))
 
   (it "does not convert attribute quotes"
     (should= attributes (convert attributes)))
 
   (it "quotes after punctuation"
-    (should-contain ".&rdquo;" (convert quote-sentence))))
+    (should-contain ".&rdquo;" (convert quote-sentence)))
+
+  (it "does not convert inside code element with class block"
+    (should= code-with-class (convert code-with-class))))

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -49,3 +49,9 @@
 
   (it "parses headers with no value"
     (should-not (:title (do-read @fs "titleWithNoValue")))))
+
+(describe "data conversions"
+  (with fs (test-fs/create-from test-pages))
+
+  (it "adds published-at-str to page"
+    (should= "31 October 2014" (:published-at-str (do-read @fs "first")))))

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -18,7 +18,14 @@
     :content "title: test: two\n"}
 
    {:path "titleWithNoValue"
-    :content "title:\n"}])
+    :content "title:\n"}
+
+   {:path "singleQuotes"
+    :content "\n---\n'singlestart' 'singleend' let's"}
+
+   {:path "doubleQuotes"
+    :content "\n---\n\"doublestart\" \"doubleend\""}]
+  )
 
 (defn do-read [fs path-str]
   (read-page (files/resolve-path fs path-str)))
@@ -54,4 +61,31 @@
   (with fs (test-fs/create-from test-pages))
 
   (it "adds published-at-str to page"
-    (should= "31 October 2014" (:published-at-str (do-read @fs "first")))))
+    (should= "31 October 2014" (:published-at-str (do-read @fs "first"))))
+
+  (it "converts starting single quote to &lsquo;"
+    (should-contain "&lsquo;singlestart" (:content (do-read @fs "singleQuotes"))))
+
+  (it "converts inner single quote to &rsquo;"
+    (should-contain "singlestart&rsquo;" (:content (do-read @fs "singleQuotes"))))
+
+  (it "converts inner single quote to &lsquo;"
+    (should-contain "&lsquo;singleend" (:content (do-read @fs "singleQuotes"))))
+
+  (it "converts ending single quote to &rsquo;"
+    (should-contain "singleend&rsquo;" (:content (do-read @fs "singleQuotes"))))
+
+  (it "converts apostrophe to &rsquo;"
+    (should-contain "let&rsquo;s" (:content (do-read @fs "singleQuotes"))))
+
+  (it "converts starting double quote to &lsquo;"
+    (should-contain "&ldquo;doublestart" (:content (do-read @fs "doubleQuotes"))))
+
+  (it "converts inner double quote to &rsquo;"
+    (should-contain "doublestart&rdquo;" (:content (do-read @fs "doubleQuotes"))))
+
+  (it "converts inner double quote to &lsquo;"
+    (should-contain "&ldquo;doubleend" (:content (do-read @fs "doubleQuotes"))))
+
+  (it "converts ending double quote to &rsquo;"
+    (should-contain "doubleend&rdquo;" (:content (do-read @fs "doubleQuotes")))))

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -19,12 +19,7 @@
 
    {:path "titleWithNoValue"
     :content "title:\n"}
-
-   {:path "singleQuotes"
-    :content "\n---\n'singlestart' 'singleend' let's"}
-
-   {:path "doubleQuotes"
-    :content "\n---\n\"doublestart\" \"doubleend\""}]
+   ]
   )
 
 (defn do-read [fs path-str]
@@ -61,31 +56,4 @@
   (with fs (test-fs/create-from test-pages))
 
   (it "adds published-at-str to page"
-    (should= "31 October 2014" (:published-at-str (do-read @fs "first"))))
-
-  (it "converts starting single quote to &lsquo;"
-    (should-contain "&lsquo;singlestart" (:content (do-read @fs "singleQuotes"))))
-
-  (it "converts inner single quote to &rsquo;"
-    (should-contain "singlestart&rsquo;" (:content (do-read @fs "singleQuotes"))))
-
-  (it "converts inner single quote to &lsquo;"
-    (should-contain "&lsquo;singleend" (:content (do-read @fs "singleQuotes"))))
-
-  (it "converts ending single quote to &rsquo;"
-    (should-contain "singleend&rsquo;" (:content (do-read @fs "singleQuotes"))))
-
-  (it "converts apostrophe to &rsquo;"
-    (should-contain "let&rsquo;s" (:content (do-read @fs "singleQuotes"))))
-
-  (it "converts starting double quote to &lsquo;"
-    (should-contain "&ldquo;doublestart" (:content (do-read @fs "doubleQuotes"))))
-
-  (it "converts inner double quote to &rsquo;"
-    (should-contain "doublestart&rdquo;" (:content (do-read @fs "doubleQuotes"))))
-
-  (it "converts inner double quote to &lsquo;"
-    (should-contain "&ldquo;doubleend" (:content (do-read @fs "doubleQuotes"))))
-
-  (it "converts ending double quote to &rsquo;"
-    (should-contain "doubleend&rdquo;" (:content (do-read @fs "doubleQuotes")))))
+    (should= "31 October 2014" (:published-at-str (do-read @fs "first")))))

--- a/spec/pinaclj/templates_spec.clj
+++ b/spec/pinaclj/templates_spec.clj
@@ -46,3 +46,4 @@
 
   (it "does not escape html in content"
     (should-contain "<h1>third</h1>" (render-third-page))))
+

--- a/spec/pinaclj/templates_spec.clj
+++ b/spec/pinaclj/templates_spec.clj
@@ -9,10 +9,11 @@
 
 (def pages [{:url "/1" :title "First post" :content "first post content."}
              {:url "/2" :title "Second post" :content "second post content." }
-             {:url "/3" :title "Third post" :content "<h1>third</h1> post content." :third-key "Hello, world!"}])
+             {:url "/3" :title "Third post" :content "<h1>third</h1> post content." :third-key "Hello, world!"}
+            {:url "/4" :title "Fourth post" :content "published" :published-at-str "31 December 2014"}])
 
-(defn render-page-link []
-   (apply str (html/emit* (test-templates/page-link (first pages)))))
+(defn render-page-link [page]
+   (apply str (html/emit* (test-templates/page-link page))))
 
 (defn render-page []
    (apply str (test-templates/page (first pages))))
@@ -25,14 +26,17 @@
 
 (describe "page link snippet"
   (it "contains href"
-    (should-contain "href=\"/1\"" (render-page-link)))
+    (should-contain "href=\"/1\"" (render-page-link (first pages))))
 
   (it "contains title"
-    (should-contain "First post" (render-page-link))))
+    (should-contain "First post" (render-page-link (first pages))))
+
+  (it "contains published-at-str"
+    (should-contain "31 December 2014" (render-page-link (nth pages 3)))))
 
 (describe "page list"
   (it "contains correct number of items"
-    (should= 3 (count (re-seq #"data-id=\"page-list-item\"" (render-page-list))))))
+    (should= (count pages) (count (re-seq #"data-id=\"page-list-item\"" (render-page-list))))))
 
 (describe "page"
   (it "renders title"

--- a/spec/pinaclj/templates_spec.clj
+++ b/spec/pinaclj/templates_spec.clj
@@ -44,5 +44,5 @@
   (it "renders all keys"
     (should-contain "Hello, world!" (render-third-page)))
 
-  (it "does not escape html in contet"
+  (it "does not escape html in content"
     (should-contain "<h1>third</h1>" (render-third-page))))

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -45,7 +45,7 @@
 
 (defn- write-templated-page [dest path content template]
    (files/create (nio/resolve-path dest path)
-                (apply str (template content))))
+                 (apply str (template content))))
 
 (defn- chronological-sort [pages]
   (reverse (sort-by :published-at pages)))

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -10,9 +10,6 @@
 (defn- render-markdown [page]
   (assoc page :content (markdown/md-to-html-string (:content page))))
 
-(defn- render [page template]
-  (apply str (template (render-markdown page))))
-
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))
 

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -10,7 +10,7 @@
   "index.html")
 
 (defn- render-markdown [page]
-  (assoc page :content (quotes/convert-quote-text (markdown/md-to-html-string (:content page)))))
+  (assoc page :content (quotes/convert (markdown/md-to-html-string (:content page)))))
 
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -2,13 +2,15 @@
   (:require [pinaclj.files :as files]
             [pinaclj.nio :as nio]
             [pinaclj.read :as rd]
-            [markdown.core :as markdown]))
+            [markdown.core :as markdown]
+            [pinaclj.quote-transform :as quotes]
+            [pinaclj.templates :as templates]))
 
 (def index-page
   "index.html")
 
 (defn- render-markdown [page]
-  (assoc page :content (markdown/md-to-html-string (:content page))))
+  (assoc page :content (quotes/convert-quote-text (markdown/md-to-html-string (:content page)))))
 
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -10,7 +10,7 @@
   "index.html")
 
 (defn- render-markdown [page]
-  (assoc page :content (quotes/convert (markdown/md-to-html-string (:content page)))))
+  (assoc page :content (quotes/transform (markdown/md-to-html-string (:content page)))))
 
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))

--- a/src/pinaclj/date_time.clj
+++ b/src/pinaclj/date_time.clj
@@ -10,5 +10,8 @@
 (defn to-str [date-time]
   (.format date-time DateTimeFormatter/ISO_INSTANT))
 
+(defn to-readable-str [date-time]
+  (.format date-time (DateTimeFormatter/ofPattern "d MMMM yyyy")))
+
 (defn from-str [value]
   (.atZone (Instant/parse value) (ZoneId/of "UTC")))

--- a/src/pinaclj/nio.clj
+++ b/src/pinaclj/nio.clj
@@ -39,7 +39,7 @@
     (Files/createDirectories parent (into-array FileAttribute []))))
 
 (defn create-file [path content]
-  (Files/write path content (into-array OpenOption [StandardOpenOption/CREATE])))
+  (Files/write path content (into-array OpenOption [])))
 
 (defn default-file-system []
   (FileSystems/getDefault))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -1,12 +1,5 @@
 (ns pinaclj.quote-transform)
 
-(defn- convert-text-segment [text]
-  (-> text
-      (clojure.string/replace #"(^|\W)(')" "$1&lsquo;")
-      (clojure.string/replace #"(\w|;)'" "$1&rsquo;")
-      (clojure.string/replace #"(^|\W)(\")" "$1&ldquo;")
-      (clojure.string/replace #"(\w|;)\"" "$1&rdquo;")))
-
 (defn- blank? [ch]
   (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))
 
@@ -46,5 +39,5 @@
                      :else
                       (append-char cur next-char)))))
 
-(defn convert [text]
+(defn transform [text]
   (:result (reduce stream-convert {} text)))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -1,8 +1,33 @@
 (ns pinaclj.quote-transform)
 
-(defn convert-quote-text [text]
+(defn- convert-text-segment [text]
   (-> text
       (clojure.string/replace #"(^|\W)(')" "$1&lsquo;")
       (clojure.string/replace #"(\w|;)'" "$1&rsquo;")
       (clojure.string/replace #"(^|\W)(\")" "$1&ldquo;")
       (clojure.string/replace #"(\w|;)\"" "$1&rdquo;")))
+
+(defn- blank? [ch]
+  (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))
+
+(defn- replace-char [next-char last-char]
+  (cond
+    (and (= \' next-char) (blank? last-char)) "&lsquo;"
+    (= \' next-char) "&rsquo;"
+    (and (= \" next-char) (blank? last-char)) "&ldquo;"
+    :else "&rdquo;"))
+
+(defn- quote-char? [ch]
+  (or (= \' ch) (= \" ch)))
+
+(defn- stream-convert [orig]
+  (:result (reduce
+    (fn [{result :result last-char :last-char} next-char]
+        (if (quote-char? next-char)
+            {:result (str result (replace-char next-char last-char)) :last-char next-char}
+            {:result (str result next-char) :last-char next-char}))
+    {:result "" :last-char nil}
+    orig)))
+
+(defn convert [text]
+  (stream-convert text))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -20,13 +20,23 @@
 (defn- quote-char? [ch]
   (or (= \' ch) (= \" ch)))
 
+(defn- in-code-block? [current-tag]
+  (= "code" current-tag))
+
 (defn- stream-convert [orig]
   (:result (reduce
-    (fn [{result :result last-char :last-char} next-char]
-        (if (quote-char? next-char)
-            {:result (str result (replace-char next-char last-char)) :last-char next-char}
-            {:result (str result next-char) :last-char next-char}))
-    {:result "" :last-char nil}
+    (fn [{result :result last-char :last-char in-tag :in-tag in-closing-tag :in-closing-tag current-tag :current-tag} next-char]
+        (cond
+          (and (not in-tag) ( not (in-code-block? current-tag)) (quote-char? next-char)) {:result (str result (replace-char next-char last-char)) :last-char next-char :in-tag in-tag :current-tag current-tag}
+          (= \< next-char) {:result (str result next-char) :last-char next-char :in-tag true :current-tag "" }
+          (= \> next-char)
+            (if in-closing-tag
+                {:result (str result next-char) :last-char next-char :in-tag false :in-closing-tag false :current-tag ""}
+                {:result (str result next-char) :last-char next-char :in-tag false :in-closing-tag false :current-tag current-tag})
+          (and in-tag (= \/ next-char)) { :result (str result next-char) :last-char next-char :in-tag in-tag :in-closing-tag true :current-tag current-tag}
+          in-tag {:result (str result next-char) :last-char next-char :in-tag in-tag :current-tag (str current-tag next-char)}
+          :else {:result (str result next-char) :last-char next-char :in-tag in-tag :current-tag current-tag }))
+    {:result "" :last-char nil :in-tag false :current-tag ""}
     orig)))
 
 (defn convert [text]

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -21,23 +21,30 @@
   (or (= \' ch) (= \" ch)))
 
 (defn- in-code-block? [current-tag]
-  (= "code" current-tag))
+  (and (not (nil? current-tag)) (.startsWith current-tag "code")))
 
-(defn- set-last-char [cur next-char]
+(defn- set-last-char [next-char cur]
   (assoc cur :last-char next-char))
 
 (defn- append-char [cur next-char]
   (assoc cur :result (str (:result cur) next-char)))
 
 (defn- stream-convert [cur next-char]
-  (let [{:keys [in-tag in-closing-tag current-tag result last-char]} cur]
-    (set-last-char (cond
-                     (and (not in-tag) (not (in-code-block? current-tag)) (quote-char? next-char)) (assoc cur :result (str result (replace-quote next-char last-char)))
-                     (= \< next-char) (assoc (append-char cur next-char) :in-tag true :current-tag "")
-                     (= \> next-char) (assoc (append-char cur next-char) :in-tag false :in-closing-tag false :current-tag (if in-closing-tag  "" current-tag))
-                     (and in-tag (= \/ next-char)) (assoc (append-char cur next-char) :in-closing-tag true)
-                     in-tag (assoc (append-char cur next-char) :current-tag (str current-tag next-char))
-                     :else (append-char cur next-char)) next-char)))
+  (set-last-char next-char
+                 (let [{:keys [in-tag in-closing-tag current-tag result last-char]} cur]
+                   (cond
+                     (and (not in-tag) (not (in-code-block? current-tag)) (quote-char? next-char))
+                      (assoc cur :result (str result (replace-quote next-char last-char)))
+                     (= \< next-char)
+                      (assoc (append-char cur next-char) :in-tag true :current-tag "")
+                     (= \> next-char)
+                      (assoc (append-char cur next-char) :in-tag false :in-closing-tag false :current-tag (if in-closing-tag  "" current-tag))
+                     (and in-tag (= \/ next-char))
+                      (assoc (append-char cur next-char) :in-closing-tag true)
+                     in-tag
+                      (assoc (append-char cur next-char) :current-tag (str current-tag next-char))
+                     :else
+                      (append-char cur next-char)))))
 
 (defn convert [text]
   (:result (reduce stream-convert {} text)))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -1,0 +1,8 @@
+(ns pinaclj.quote-transform)
+
+(defn convert-quote-text [text]
+  (-> text
+      (clojure.string/replace #"(^|\W)(')" "$1&lsquo;")
+      (clojure.string/replace #"(\w|;)'" "$1&rsquo;")
+      (clojure.string/replace #"(^|\W)(\")" "$1&ldquo;")
+      (clojure.string/replace #"(\w|;)\"" "$1&rdquo;")))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -10,7 +10,7 @@
 (defn- blank? [ch]
   (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))
 
-(defn- replace-char [next-char last-char]
+(defn- replace-quote [next-char last-char]
   (cond
     (and (= \' next-char) (blank? last-char)) "&lsquo;"
     (= \' next-char) "&rsquo;"
@@ -23,21 +23,21 @@
 (defn- in-code-block? [current-tag]
   (= "code" current-tag))
 
-(defn- stream-convert [orig]
-  (:result (reduce
-    (fn [{result :result last-char :last-char in-tag :in-tag in-closing-tag :in-closing-tag current-tag :current-tag} next-char]
-        (cond
-          (and (not in-tag) ( not (in-code-block? current-tag)) (quote-char? next-char)) {:result (str result (replace-char next-char last-char)) :last-char next-char :in-tag in-tag :current-tag current-tag}
-          (= \< next-char) {:result (str result next-char) :last-char next-char :in-tag true :current-tag "" }
-          (= \> next-char)
-            (if in-closing-tag
-                {:result (str result next-char) :last-char next-char :in-tag false :in-closing-tag false :current-tag ""}
-                {:result (str result next-char) :last-char next-char :in-tag false :in-closing-tag false :current-tag current-tag})
-          (and in-tag (= \/ next-char)) { :result (str result next-char) :last-char next-char :in-tag in-tag :in-closing-tag true :current-tag current-tag}
-          in-tag {:result (str result next-char) :last-char next-char :in-tag in-tag :current-tag (str current-tag next-char)}
-          :else {:result (str result next-char) :last-char next-char :in-tag in-tag :current-tag current-tag }))
-    {:result "" :last-char nil :in-tag false :current-tag ""}
-    orig)))
+(defn- set-last-char [cur next-char]
+  (assoc cur :last-char next-char))
+
+(defn- append-char [cur next-char]
+  (assoc cur :result (str (:result cur) next-char)))
+
+(defn- stream-convert [cur next-char]
+  (let [{:keys [in-tag in-closing-tag current-tag result last-char]} cur]
+    (set-last-char (cond
+                     (and (not in-tag) (not (in-code-block? current-tag)) (quote-char? next-char)) (assoc cur :result (str result (replace-quote next-char last-char)))
+                     (= \< next-char) (assoc (append-char cur next-char) :in-tag true :current-tag "")
+                     (= \> next-char) (assoc (append-char cur next-char) :in-tag false :in-closing-tag false :current-tag (if in-closing-tag  "" current-tag))
+                     (and in-tag (= \/ next-char)) (assoc (append-char cur next-char) :in-closing-tag true)
+                     in-tag (assoc (append-char cur next-char) :current-tag (str current-tag next-char))
+                     :else (append-char cur next-char)) next-char)))
 
 (defn convert [text]
-  (stream-convert text))
+  (:result (reduce stream-convert {} text)))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -28,16 +28,6 @@
     (assoc page :published-at-str (date-time/to-readable-str (:published-at page)))
     page))
 
-(defn- convert-quote-text [text]
-  (-> text
-      (clojure.string/replace #"(^|\W)(')" "&lsquo;")
-      (clojure.string/replace #"(\w)'" "$1&rsquo;")
-      (clojure.string/replace #"(^|\W)(\")" "&ldquo;")
-      (clojure.string/replace #"(\w)\"" "$1&rdquo;")))
-
-(defn- convert-quotes [page]
-  (assoc page :content (convert-quote-text (:content page))))
-
 (defn parse-page [path]
   (let [header-and-content (split-header-content (files/read-lines path))]
     (merge {:content (second header-and-content)}
@@ -47,5 +37,4 @@
   (-> path
       (parse-page)
       (convert-published-at)
-      (add-published-at-str)
-      (convert-quotes)))
+      (add-published-at-str)))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -23,8 +23,13 @@
     (assoc headers :published-at (date-time/from-str published-at))
     headers))
 
+(defn- add-published-at-str [page]
+  (if-let [published-at (:published-at page)]
+    (assoc page :published-at-str (date-time/to-readable-str (:published-at page)))
+    page))
+
 (defn read-page [path]
   (let [header-and-content (split-header-content (files/read-lines path))
         headers (to-headers (first header-and-content))]
-    (merge {:content (second header-and-content)}
-           (convert-published-at headers))))
+    (add-published-at-str (merge {:content (second header-and-content)}
+           (convert-published-at headers)))))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -28,6 +28,3 @@
         headers (to-headers (first header-and-content))]
     (merge {:content (second header-and-content)}
            (convert-published-at headers))))
-
-(defn- read-all-pages [path]
-  (map read-page (files/all-in path)))

--- a/src/pinaclj/templates.clj
+++ b/src/pinaclj/templates.clj
@@ -1,19 +1,6 @@
 (ns pinaclj.templates
   (:require [net.cgrand.enlive-html :as html]))
 
-(defn build-link-func [page-obj]
-  (html/snippet page-obj
-  [(html/attr= :data-id "page-link")]
-  [page]
-  [(html/attr= :data-id "page-link")] (html/do-> (html/set-attr :href (:url page))
-                                   (html/content (:title page)))))
-
-(defn build-list-func [page-obj link-func]
-  (html/template page-obj [pages]
-                 [[(html/attr= :data-id "page-list")] [(html/attr= :data-id "page-list-item")]]
-                 (html/clone-for [item pages]
-                                 [(html/attr= :data-id "page-list-item")] (html/content (link-func item)))))
-
 (defn- build-replacement-selector [kv]
   [(html/attr= :data-id (name (first kv)))])
 
@@ -22,7 +9,7 @@
     (assoc node :content (html/html-snippet (second kv)))))
 
 (defn- build-replacement-kv [kv]
-  (vec (list (build-replacement-selector kv) (build-replacement-transform kv))))
+  (doall (list (build-replacement-selector kv) (build-replacement-transform kv))))
 
 (defn- build-replacement-list [page]
   (map build-replacement-kv page))
@@ -33,3 +20,19 @@
 (defn build-page-func [page-obj]
   (html/template page-obj [page] [:body] (page-replace page)))
 
+(defn build-link-func [page-obj]
+  (html/snippet page-obj
+                [(html/attr= :data-id "page-list-item")]
+                [page]
+                [(html/attr= :data-id "page-link")]
+                (html/do-> (html/set-attr :href (:url page))
+                (html/content (:title page)))
+                [(html/attr= :data-id "published-at-str")]
+                (html/content (:published-at-str page))
+                ))
+
+(defn build-list-func [page-obj link-func]
+  (html/template page-obj [pages]
+                 [[(html/attr= :data-id "page-list-item")]]
+                 (html/clone-for [item pages]
+                                 [(html/attr= :data-id "page-list-item")] (html/substitute (link-func item)))))

--- a/src/pinaclj/templates.clj
+++ b/src/pinaclj/templates.clj
@@ -32,3 +32,4 @@
 
 (defn build-page-func [page-obj]
   (html/template page-obj [page] [:body] (page-replace page)))
+


### PR DESCRIPTION
Two changes related to content transformations:
1. Generate `published-at-str` and use it in the page-link transformation.
2. Transform quotes, after Markdown has been translated to HTML but before it is sent to Enlive.

The `published-at-str` still needs some work to genericize how the page-link transformation works, but I'd like to get this merged first as I feel that's a longer task.