### PR TITLE
Dashes

### DIFF
--- a/spec/example_theme/post.html
+++ b/spec/example_theme/post.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <h1  data-id="title"></h1>

--- a/spec/pinaclj/core_spec.clj
+++ b/spec/pinaclj/core_spec.clj
@@ -43,7 +43,7 @@
                test-templates/page-list))
 
 (defn- render-page-list [fs]
-  (apply str (compile-page fs)))
+  (templates/to-str (compile-page fs)))
 
 (defn- index-contents [fs]
   (files/content (files/resolve-path fs "published/index.html")))
@@ -79,7 +79,10 @@
       (should (files/exists? (files/resolve-path @fs "published/a/blog/page/index.html"))))
 
     (it "transforms quotes"
-      (should-contain "‘" (files/content (files/resolve-path @fs "published/quote_test.html")))))
+      (should-contain "‘" (files/content (files/resolve-path @fs "published/quote_test.html"))))
+
+    (it "transforms relative urls"
+      (should-contain "../styles.css" (files/content (files/resolve-path @fs "published/nested/another_post.html")))))
 
   (describe "index page"
     (it "renders an index page"

--- a/spec/pinaclj/link_transform_spec.clj
+++ b/spec/pinaclj/link_transform_spec.clj
@@ -1,0 +1,51 @@
+(ns pinaclj.link-transform-spec
+  (require [speclj.core :refer :all]
+           [pinaclj.link-transform :refer :all]))
+
+(def root-page
+  {:content {:attrs {:src "index.html"}}
+   :url "test.html" })
+
+(def one-deep
+  {:content {:attrs {:src "styles.css"}}
+   :url "dir/test.html" })
+
+(def two-deep
+  {:content {:attrs {:src "styles.css"}}
+   :url "dir/two/test.html" })
+
+(def href
+  {:content {:attrs {:href "hello.png"}}
+   :url "another/page/here.html"})
+
+(def hierarchy
+  {:content {:content '({:attrs {:src "deep.png"}})}
+   :url "one/two/three.html"})
+
+(def external-site
+  {:content {:attrs {:src "//another.com/page.png"}}
+    :url "dir/index.html"})
+
+(def unpack-single-node
+  (comp :src :attrs :content))
+
+(describe "convert-page"
+  (it "does not change for root level"
+    (should= "index.html"
+      (unpack-single-node (convert-page root-page))))
+  (it "changes for one level up"
+    (should= "../styles.css"
+      (unpack-single-node (convert-page one-deep))))
+  (it "changes for two levels up"
+    (should= "../../styles.css"
+      (unpack-single-node (convert-page two-deep))))
+  (it "changes href"
+    (should= "../../hello.png"
+      (:href (:attrs (:content (convert-page href))))))
+  (it "traverses tree"
+    (should= "../../deep.png"
+      (:src (:attrs (first (:content (:content (convert-page hierarchy))))))))
+  (it "does not change external pages"
+    (should= "//another.com/page.png"
+      (unpack-single-node (convert-page external-site)))))
+

--- a/spec/pinaclj/link_transform_spec.clj
+++ b/spec/pinaclj/link_transform_spec.clj
@@ -29,23 +29,23 @@
 (def unpack-single-node
   (comp :src :attrs :content))
 
-(describe "convert-page"
+(describe "transform"
   (it "does not change for root level"
     (should= "index.html"
-      (unpack-single-node (convert-page root-page))))
+      (unpack-single-node (transform root-page))))
   (it "changes for one level up"
     (should= "../styles.css"
-      (unpack-single-node (convert-page one-deep))))
+      (unpack-single-node (transform one-deep))))
   (it "changes for two levels up"
     (should= "../../styles.css"
-      (unpack-single-node (convert-page two-deep))))
+      (unpack-single-node (transform two-deep))))
   (it "changes href"
     (should= "../../hello.png"
-      (:href (:attrs (:content (convert-page href))))))
+      (:href (:attrs (:content (transform href))))))
   (it "traverses tree"
     (should= "../../deep.png"
-      (:src (:attrs (first (:content (:content (convert-page hierarchy))))))))
+      (:src (:attrs (first (:content (:content (transform hierarchy))))))))
   (it "does not change external pages"
     (should= "//another.com/page.png"
-      (unpack-single-node (convert-page external-site)))))
+      (unpack-single-node (transform external-site)))))
 

--- a/spec/pinaclj/punctuation_transform_spec.clj
+++ b/spec/pinaclj/punctuation_transform_spec.clj
@@ -61,11 +61,11 @@
     (should-contain ".&rdquo;" (transform-quotes quote-sentence))))
 
 (describe "transform-dashes"
-  (it "emdash"
-    (should-contain "&emdash;" (transform-dashes "--")))
+  (it "mdash"
+    (should-contain "&mdash;" (transform-dashes "--")))
 
-  (it "endash"
-    (should-contain "&endash;" (transform-dashes " - ")))
+  (it "ndash"
+    (should-contain "&ndash;" (transform-dashes " - ")))
 
   (it "hyphen"
     (should-contain "-" (transform-dashes "bleeding-edge"))))

--- a/spec/pinaclj/punctuation_transform_spec.clj
+++ b/spec/pinaclj/punctuation_transform_spec.clj
@@ -1,6 +1,6 @@
-(ns pinaclj.quote-transform-spec
+(ns pinaclj.punctuation-transform-spec
   (:require [speclj.core :refer :all]
-            [pinaclj.quote-transform :refer :all]))
+            [pinaclj.punctuation-transform :refer :all]))
 
 (def no-quotes
   "abc")

--- a/spec/pinaclj/punctuation_transform_spec.clj
+++ b/spec/pinaclj/punctuation_transform_spec.clj
@@ -17,6 +17,9 @@
 (def inside-code-block
   {:tag :code :content "'"})
 
+(def inside-script
+  {:tag :script :content "'"})
+
 (def attributes
   {:tag :img :attrs {:src "t'est"} :content nil})
 
@@ -86,6 +89,9 @@
 
   (it "nothing inside code block"
     (should= inside-code-block (transform inside-code-block)))
+
+  (it "nothing inside script"
+    (should= inside-script (transform inside-script)))
 
   (it "nothing inside attributes"
     (should= attributes (transform attributes))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -29,53 +29,57 @@
 (def tag-list
   '({:tag :p :content "'"} {:tag :p :content "'"}))
 
-(describe "transforms"
+(describe "transform-quotes"
   (it "starting single quote to &lsquo;"
-    (should-contain "&lsquo;singlestart" (transform-text single-quotes)))
+    (should-contain "&lsquo;singlestart" (transform-quotes single-quotes)))
 
   (it "inner single quote to &rsquo;"
-    (should-contain "singlestart&rsquo;" (transform-text single-quotes)))
+    (should-contain "singlestart&rsquo;" (transform-quotes single-quotes)))
 
   (it "inner single quote to &lsquo;"
-    (should-contain "&lsquo;singleend" (transform-text single-quotes)))
+    (should-contain "&lsquo;singleend" (transform-quotes single-quotes)))
 
   (it "ending single quote to &rsquo;"
-    (should-contain "singleend&rsquo;" (transform-text single-quotes)))
+    (should-contain "singleend&rsquo;" (transform-quotes single-quotes)))
 
   (it "apostrophe to &rsquo;"
-    (should-contain "let&rsquo;s" (transform-text single-quotes)))
+    (should-contain "let&rsquo;s" (transform-quotes single-quotes)))
 
   (it "starting double quote to &lsquo;"
-    (should-contain "&ldquo;doublestart" (transform-text double-quotes)))
+    (should-contain "&ldquo;doublestart" (transform-quotes double-quotes)))
 
   (it "inner double quote to &rsquo;"
-    (should-contain "doublestart&rdquo;" (transform-text double-quotes)))
+    (should-contain "doublestart&rdquo;" (transform-quotes double-quotes)))
 
   (it "inner double quote to &lsquo;"
-    (should-contain "&ldquo;doubleend" (transform-text double-quotes)))
+    (should-contain "&ldquo;doubleend" (transform-quotes double-quotes)))
 
   (it "ending double quote to &rsquo;"
-    (should-contain "doubleend&rdquo;" (transform-text double-quotes)))
-
-  (it "inside html"
-    (should= "‘" (:content (transform inside-html))))
+    (should-contain "doubleend&rdquo;" (transform-quotes double-quotes)))
 
   (it "quotes after punctuation"
-    (should-contain ".&rdquo;" (transform-text quote-sentence)))
+    (should-contain ".&rdquo;" (transform-quotes quote-sentence))))
+
+(describe "transform-dashes"
+  (it "emdash"
+    (should-contain "&emdash;" (transform-dashes "--"))))
+
+(describe "transform"
 
   (it "nested tag"
     (should= "‘" (:content (:content (transform nested-tag)))))
 
   (it "tag list"
-    (should= "‘" (:content (second (transform tag-list))))))
+    (should= "‘" (:content (second (transform tag-list)))))
 
-(describe "does not transform"
+  (it "inside html"
+    (should= "‘" (:content (transform inside-html))))
 
-  (it "string with no quotes"
+  (it "string"
     (should= no-quotes (transform no-quotes)))
 
-  (it "inside code block"
+  (it "nothing inside code block"
     (should= inside-code-block (transform inside-code-block)))
 
-  (it "attribute quotes"
+  (it "nothing inside attributes"
     (should= attributes (transform attributes))))

--- a/spec/pinaclj/quote_transform_spec.clj
+++ b/spec/pinaclj/quote_transform_spec.clj
@@ -62,7 +62,13 @@
 
 (describe "transform-dashes"
   (it "emdash"
-    (should-contain "&emdash;" (transform-dashes "--"))))
+    (should-contain "&emdash;" (transform-dashes "--")))
+
+  (it "endash"
+    (should-contain "&endash;" (transform-dashes " - ")))
+
+  (it "hyphen"
+    (should-contain "-" (transform-dashes "bleeding-edge"))))
 
 (describe "transform"
 

--- a/spec/pinaclj/templates_spec.clj
+++ b/spec/pinaclj/templates_spec.clj
@@ -13,16 +13,16 @@
             {:url "/4" :title "Fourth post" :content "published" :published-at-str "31 December 2014"}])
 
 (defn render-page-link [page]
-   (apply str (html/emit* (test-templates/page-link page))))
+   (to-str (html/emit* (test-templates/page-link page))))
 
 (defn render-page []
-   (apply str (test-templates/page (first pages))))
+   (to-str (test-templates/page (first pages))))
 
 (defn render-third-page []
-  (apply str (test-templates/page (nth pages 2))))
+  (to-str (test-templates/page (nth pages 2))))
 
 (defn render-page-list []
-   (apply str (test-templates/page-list pages)))
+   (to-str (test-templates/page-list pages)))
 
 (describe "page link snippet"
   (it "contains href"

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -9,8 +9,11 @@
 (def index-page
   "index.html")
 
-(defn- render-markdown [page]
-  (assoc page :content (punctuation/transform (md/to-clj (md/mp (:content page))))))
+(defn- apply-content-transforms [page]
+  (assoc page :content (-> (:content page)
+                           md/mp
+                           md/to-clj
+                           punctuation/transform)))
 
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))
@@ -38,8 +41,8 @@
 
 (defn- compile-page [src page-path]
   (let [page (rd/read-page page-path)]
-    (if (published? page)
-        (render-markdown
+    (when (published? page)
+        (apply-content-transforms
           (assoc page :url (publication-path page src page-path))))))
 
 (defn- compile-pages [src files]

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -46,9 +46,9 @@
 (defn- compile-page [src page-path]
   (let [page (rd/read-page page-path)]
     (when (published? page)
-        (assoc page
-               :url (publication-path page src page-path)
-               :content (render-markdown (:content page))))))
+      (assoc page
+             :url (publication-path page src page-path)
+             :content (render-markdown (:content page))))))
 
 (defn- compile-pages [src files]
   (remove nil? (map (partial compile-page src) files)))

--- a/src/pinaclj/core.clj
+++ b/src/pinaclj/core.clj
@@ -3,14 +3,14 @@
             [pinaclj.nio :as nio]
             [pinaclj.read :as rd]
             [endophile.core :as md]
-            [pinaclj.quote-transform :as quotes]
+            [pinaclj.punctuation-transform :as punctuation]
             [pinaclj.templates :as templates]))
 
 (def index-page
   "index.html")
 
 (defn- render-markdown [page]
-  (assoc page :content (quotes/transform (md/to-clj (md/mp (:content page))))))
+  (assoc page :content (punctuation/transform (md/to-clj (md/mp (:content page))))))
 
 (def build-destination
   (comp files/change-extension-to-html nio/relativize))

--- a/src/pinaclj/link_transform.clj
+++ b/src/pinaclj/link_transform.clj
@@ -27,7 +27,7 @@
       (assoc node
              :attrs (convert-attrs (:attrs node) page-depth)
              :content (convert-urls (:content node) page-depth))
-    (seq? node)
+    (or (seq? node) (vector? node))
       (doall (map #(convert-urls % page-depth) node))
     :else
       node))
@@ -35,7 +35,7 @@
 (defn- page-depth [page]
   (count (filter #(= \/ %) (:url page))))
 
-(defn convert-page [page]
+(defn transform [page]
   (let [page-depth (page-depth page)]
     (if (pos? page-depth)
       (assoc page :content (convert-urls (:content page) page-depth))

--- a/src/pinaclj/link_transform.clj
+++ b/src/pinaclj/link_transform.clj
@@ -1,0 +1,42 @@
+(ns pinaclj.link-transform)
+
+(defn relative-url? [url]
+   (not (re-find #"\/\/" url)))
+
+(defn- up-dir-str [page-depth]
+  (apply str (repeat page-depth "../")))
+
+(defn- convert-url [url page-depth]
+  (if (relative-url? url)
+    (str (up-dir-str page-depth) url)
+    url))
+
+(defn- convert-attr [attrs attr page-depth]
+  (if (contains? attrs attr)
+    (assoc attrs attr (convert-url (get attrs attr) page-depth))
+    attrs))
+
+(defn- convert-attrs [attrs page-depth]
+  (-> attrs
+      (convert-attr :src page-depth)
+      (convert-attr :href page-depth)))
+
+(defn- convert-urls [node page-depth]
+  (cond
+    (map? node)
+      (assoc node
+             :attrs (convert-attrs (:attrs node) page-depth)
+             :content (convert-urls (:content node) page-depth))
+    (seq? node)
+      (doall (map #(convert-urls % page-depth) node))
+    :else
+      node))
+
+(defn- page-depth [page]
+  (count (filter #(= \/ %) (:url page))))
+
+(defn convert-page [page]
+  (let [page-depth (page-depth page)]
+    (if (pos? page-depth)
+      (assoc page :content (convert-urls (:content page) page-depth))
+      page)))

--- a/src/pinaclj/punctuation_transform.clj
+++ b/src/pinaclj/punctuation_transform.clj
@@ -36,8 +36,8 @@
 
 (defn transform-dashes [text]
   (-> text
-      (clojure.string/replace "--" "&emdash;")
-      (clojure.string/replace " - " "&endash;")))
+      (clojure.string/replace "--" "&mdash;")
+      (clojure.string/replace " - " "&ndash;")))
 
 (defn transform [node]
   (transform-non-code node (comp transform-quotes transform-dashes)))

--- a/src/pinaclj/punctuation_transform.clj
+++ b/src/pinaclj/punctuation_transform.clj
@@ -26,7 +26,7 @@
       (first (html/html-snippet (string-fn node)))
     (and (map? node) (not (= :code (:tag node))))
       (assoc node :content (transform-non-code (:content node) string-fn))
-    (seq? node)
+    (or (seq? node) (vector? node))
       (map #(transform-non-code % string-fn) node)
     :else
       node))

--- a/src/pinaclj/punctuation_transform.clj
+++ b/src/pinaclj/punctuation_transform.clj
@@ -1,4 +1,4 @@
-(ns pinaclj.quote-transform
+(ns pinaclj.punctuation-transform
     (:require [net.cgrand.enlive-html :as html]))
 
 (defn- blank? [ch]

--- a/src/pinaclj/punctuation_transform.clj
+++ b/src/pinaclj/punctuation_transform.clj
@@ -1,6 +1,9 @@
 (ns pinaclj.punctuation-transform
     (:require [net.cgrand.enlive-html :as html]))
 
+(def ignored-tags
+  [:code :script])
+
 (defn- blank? [ch]
   (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))
 
@@ -24,7 +27,7 @@
   (cond
     (string? node)
       (first (html/html-snippet (string-fn node)))
-    (and (map? node) (not (= :code (:tag node))))
+    (and (map? node) (not (.contains ignored-tags (:tag node))))
       (assoc node :content (transform-non-code (:content node) string-fn))
     (or (seq? node) (vector? node))
       (map #(transform-non-code % string-fn) node)

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -2,7 +2,9 @@
     (:require [net.cgrand.enlive-html :as html]))
 
 (defn transform-dashes [text]
-  (clojure.string/replace text "--" "&emdash;"))
+  (-> text
+      (clojure.string/replace "--" "&emdash;")
+      (clojure.string/replace " - " "&endash;")))
 
 (defn- blank? [ch]
   (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))

--- a/src/pinaclj/quote_transform.clj
+++ b/src/pinaclj/quote_transform.clj
@@ -1,11 +1,6 @@
 (ns pinaclj.quote-transform
     (:require [net.cgrand.enlive-html :as html]))
 
-(defn transform-dashes [text]
-  (-> text
-      (clojure.string/replace "--" "&emdash;")
-      (clojure.string/replace " - " "&endash;")))
-
 (defn- blank? [ch]
   (or (nil? ch) (Character/isWhitespace ch) (= \> ch)))
 
@@ -25,9 +20,6 @@
                                             next-char))
          :last-char next-char))
 
-(defn transform-quotes [text]
-  (:result (reduce stream-convert {} text)))
-
 (defn- transform-non-code [node string-fn]
   (cond
     (string? node)
@@ -38,6 +30,14 @@
       (map #(transform-non-code % string-fn) node)
     :else
       node))
+
+(defn transform-quotes [text]
+  (:result (reduce stream-convert {} text)))
+
+(defn transform-dashes [text]
+  (-> text
+      (clojure.string/replace "--" "&emdash;")
+      (clojure.string/replace " - " "&endash;")))
 
 (defn transform [node]
   (transform-non-code node (comp transform-quotes transform-dashes)))

--- a/src/pinaclj/templates.clj
+++ b/src/pinaclj/templates.clj
@@ -17,7 +17,7 @@
   #(html/at* % (build-replacement-list page)))
 
 (defn build-page-func [page-obj]
-  (html/template page-obj [page] [html/root] (page-replace page)))
+  (html/snippet page-obj [html/root] [page] [html/root] (page-replace page)))
 
 (defn build-link-func [page-obj]
   (html/snippet page-obj
@@ -31,7 +31,10 @@
                 ))
 
 (defn build-list-func [page-obj link-func]
-  (html/template page-obj [pages]
+  (html/snippet page-obj [html/root] [pages]
                  [[(html/attr= :data-id "page-list-item")]]
                  (html/clone-for [item pages]
                                  [(html/attr= :data-id "page-list-item")] (html/substitute (link-func item)))))
+
+(defn to-str [nodes]
+  (apply str (html/emit* nodes)))


### PR DESCRIPTION
Two major features:

1. Relative links in theme files (like href="styles.css", src="me.png") are now correct for pages which are output to nested dirs. So if you output to /blog/2014/06/02/my_page/index.html then "styles.css" will become "../../../../../styles.css". The upshot is that you can browse your entire site locally.

2. "--" are converted to &mdash; and "9 - 5" is converted to "9 &ndash; 5". Hyphens (like bleeding-edge) are not touched. This is part of "punctuation-transform" and I think I've completed that now.

This is based on the change to Endophile which is already in master. That means a lot of transformation now gets performed on the Enlive tag structures. Core has an "apply-transforms" function which possibly points to the beginnings of plugin support.