### PR TITLE
Introducing fatal validation

### DIFF
--- a/resources/dictionary.clj
+++ b/resources/dictionary.clj
@@ -3,6 +3,7 @@
         :already-published "The file %s is already published."
         :was-published "The file %s has been published at %s."
         :no-separator "The file %s has no header separator of '---'"
+        :no-title "The file %s has no 'title: ' in the header"
         }
        :generate
        {:published-page "Published: %s"

--- a/resources/dictionary.clj
+++ b/resources/dictionary.clj
@@ -2,6 +2,7 @@
        {:not-found "The specified file %s was not found."
         :already-published "The file %s is already published."
         :was-published "The file %s has been published at %s."
+        :no-separator "The file %s has no header separator of '---'"
         }
        :generate
        {:published-page "Published: %s"

--- a/spec/pinaclj/files_spec.clj
+++ b/spec/pinaclj/files_spec.clj
@@ -18,6 +18,10 @@
 (def hidden-file
   [{:path ".hidden"}])
 
+(def duplicate-files
+  [{:path "from/sub/file.txt"}
+   {:path "to/existing.txt"}])
+
 (defn- file-count [fs]
   (count (files/all-in (files/resolve-path fs "/"))))
 
@@ -36,3 +40,14 @@
 
   (it "does not include hidden files"
     (should= 0 (file-count (test-fs/create-from hidden-file)))))
+
+(describe :duplicate-if-newer
+  (with fs (test-fs/create-from duplicate-files))
+
+  (it "creates non-existing directories"
+    (let [src (files/resolve-path @fs "from")
+          dest (files/resolve-path @fs "to")
+          file (files/resolve-path @fs "from/sub/file.txt")]
+      (files/duplicate-if-newer src dest file)
+      (should (files/exists? (files/resolve-path @fs "to/sub/file.txt"))))))
+

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -69,18 +69,12 @@
   (it "does not set published-at for pages with no separator"
       (should= nil (:published-at (do-read @fs "pageWithNoSeparator"))))
 
-  (it "returns failure when page has no separator"
-      (should= :invalid-source-file (:result (do-read @fs "pageWithNoSeparator"))))
-
   (it "returns error description when page has no separator"
-      (should= [:no-separator] (:errors (do-read @fs "pageWithNoSeparator"))))
+      (should= [[:error :no-separator]] ((:issues (do-read @fs "pageWithNoSeparator")) )))
 
   (it "does not set published-at for pages with no title"
       (should= nil (:published-at (do-read @fs "pageWithNoTitle"))))
 
-  (it "returns failure when page has no title"
-      (should= :invalid-source-file (:result (do-read @fs "pageWithNoTitle"))))
-
   (it "returns error description when page has no title"
-      (should= [:no-title] (:errors (do-read @fs "pageWithNoTitle"))))
+      (should= [[:error :no-title]] (:issues (do-read @fs "pageWithNoTitle"))))
 )

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -68,4 +68,7 @@
 
   (it "returns failure when page has no separator"
       (should= :invalid-source-file (:result (do-read @fs "pageWithNoSeparator"))))
+
+  (it "returns error description when page has no separator"
+      (should= [:no-separator] (:errors (do-read @fs "pageWithNoSeparator"))))
 )

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -28,6 +28,9 @@
 
    {:path "pageWithNoSeparator"
     :content "title: title\nbody"}
+
+   {:path "pageWithNoTitle"
+    :content "wrong: test\n---"}
    ])
 
 (defn do-read [fs path-str]
@@ -71,4 +74,13 @@
 
   (it "returns error description when page has no separator"
       (should= [:no-separator] (:errors (do-read @fs "pageWithNoSeparator"))))
+
+  (it "does not set published-at for pages with no title"
+      (should= nil (:published-at (do-read @fs "pageWithNoTitle"))))
+
+  (it "returns failure when page has no title"
+      (should= :invalid-source-file (:result (do-read @fs "pageWithNoTitle"))))
+
+  (it "returns error description when page has no title"
+      (should= [:no-title] (:errors (do-read @fs "pageWithNoTitle"))))
 )

--- a/spec/pinaclj/read_spec.clj
+++ b/spec/pinaclj/read_spec.clj
@@ -18,13 +18,16 @@
     :content "title: foo\nhello: World\n---\none\ntwo" }
 
    {:path "titleWithColon"
-    :content "title: test: two\n"}
+    :content "title: test: two\n---"}
 
    {:path "titleWithNoValue"
     :content "title:\n"}
 
    {:path "longPage"
     :content (str "---\n" (apply str (repeat 200 "ab ")))}
+
+   {:path "pageWithNoSeparator"
+    :content "title: title\nbody"}
    ])
 
 (defn do-read [fs path-str]
@@ -58,4 +61,11 @@
     (should= "test: two" (:title (do-read @fs "titleWithColon"))))
 
   (it "parses headers with no value"
-    (should-not (:title (do-read @fs "titleWithNoValue")))))
+    (should-not (:title (do-read @fs "titleWithNoValue"))))
+
+  (it "does not set published-at for pages with no separator"
+      (should= nil (:published-at (do-read @fs "pageWithNoSeparator"))))
+
+  (it "returns failure when page has no separator"
+      (should= :invalid-source-file (:result (do-read @fs "pageWithNoSeparator"))))
+)

--- a/spec/pinaclj/tasks/publish_spec.clj
+++ b/spec/pinaclj/tasks/publish_spec.clj
@@ -20,11 +20,15 @@
   {:path "rewrite.md"
    :content "title: test\npublished-at: 2015-01-01T15:00:00.102Z\n---\ntest2"})
 
+(def no-separator
+  {:path "no-separator.md"
+   :content "title: test\ntest2"})
+
 (defn- publish-one [fs path]
   (last (publish fs [path] test-time)))
 
 (describe "publish"
-  (with fs (create-from [simple-page rewrite page-2]))
+  (with fs (create-from [simple-page rewrite page-2 no-separator]))
 
   (describe "with unpublished page"
     (it "outputs published message"
@@ -67,4 +71,11 @@
     (it "publishes two files"
       (publish @fs ["test.md" "test2.md"] test-time)
       (should-contain "published-at" (read-file @fs "test.md"))
-      (should-contain "published-at" (read-file @fs "test2.md")))))
+      (should-contain "published-at" (read-file @fs "test2.md"))))
+          
+  (describe "with invalid source file"
+    (it "outputs fatal message when separator missing"
+        (let [message (publish-one @fs "no-separator.md")]
+          (should-contain "no header separator of '---'" (:msg message))
+          (should-contain "no-separator.md" (:msg message))
+          (should= :fatal (:type message))))))

--- a/spec/pinaclj/templates_spec.clj
+++ b/spec/pinaclj/templates_spec.clj
@@ -9,11 +9,11 @@
 (defn- to-snippet [body]
   (html/html-snippet (str "<html><body>" body "</body></html>")))
 
-(defn- template [body all-pages]
-  (build-page-func (to-snippet body) all-pages))
+(defn- template [body]
+  (build-template-from-resource (to-snippet body)))
 
 (defn- do-replace [template-body-str page all-pages]
-  (to-str ((template template-body-str all-pages) page)))
+  (to-str (((:template-fn (template template-body-str)) all-pages) page)))
 
 (def page-template
   "<p data-id=a /><p data-id=b /><p data-id=c />")
@@ -64,7 +64,7 @@
 (def delete-page
   {:if-exists {:delete true}})
 
-(describe "build-page-func"
+(describe "build-template"
   (it "transforms string values"
     (let [result (do-replace page-template string-value-page {})]
       (should-contain "testA" result)
@@ -107,7 +107,10 @@
       (should-contain ":url1:url2" result)))
 
   (it "deletes nodes"
-    (should-not-contain "bye" (do-replace delete-page-template delete-page {}))))
+    (should-not-contain "bye" (do-replace delete-page-template delete-page {})))
+  
+  (it "sets :data-ids appropriately"
+    (should= #{:a :b :c} (:data-ids (template page-template)))))
 
 (describe "build-page-list-opts"
   (def page-list-opts
@@ -150,7 +153,7 @@
 
 (describe "page with multiple occurrences of func"
   (it "lists selector only once"
-    (should= ["func"] (find-all-functions (to-snippet multiple-selector-template)))))
+    (should= ["func"] (find-all-data-ids (to-snippet multiple-selector-template)))))
 
 (def set-only-attr-template
   "<p data-id=a data-set=attrs />")

--- a/spec/pinaclj/transforms/page_list_spec.clj
+++ b/spec/pinaclj/transforms/page_list_spec.clj
@@ -33,4 +33,4 @@
   (it "restricts to max-pages if set"
     (should= 2 (count (:pages (clone-pages all-pages max-page-opts)))))
   (it "restricts when max-pages is larger than page set"
-    (should= 2 (count (:pages (clone-pages all-pages high-max-page-opts))))))
+    (should= 4 (count (:pages (clone-pages all-pages high-max-page-opts))))))

--- a/spec/pinaclj/transforms/page_list_spec.clj
+++ b/spec/pinaclj/transforms/page_list_spec.clj
@@ -20,6 +20,9 @@
 (def max-page-opts
   (assoc page-map-opts :max-pages "2"))
 
+(def high-max-page-opts
+  (assoc page-map-opts :max-pages "6"))
+
 (describe "clone-pages"
   (it "provides all child pages if no :pages set"
     (should== ["url1" "url2" "url3" "url4"] (:pages (clone-pages {} page-map-opts))))
@@ -28,4 +31,6 @@
   (it "ignores :pages if :max-pages is not set"
     (should= 4 (count (:pages (clone-pages some-pages page-map-opts)))))
   (it "restricts to max-pages if set"
-    (should= 2 (count (:pages (clone-pages all-pages max-page-opts))))))
+    (should= 2 (count (:pages (clone-pages all-pages max-page-opts)))))
+  (it "restricts when max-pages is larger than page set"
+    (should= 2 (count (:pages (clone-pages all-pages high-max-page-opts))))))

--- a/src/leiningen/publish.clj
+++ b/src/leiningen/publish.clj
@@ -14,4 +14,5 @@
   (doall (for [message (task/publish fs args dt/now)]
            (case (:type message)
                  :success (main/info (:msg message))
-                 :error (main/warn (:msg message))))))
+                 :error (main/warn (:msg message))
+                 :fatal (main/abort (:msg message))))))

--- a/src/pinaclj/files.clj
+++ b/src/pinaclj/files.clj
@@ -68,4 +68,5 @@
   (let [relative-path (nio/relativize src-root src-file)
         new-path (nio/resolve-path dest-root relative-path)]
     (when (< (timestamp new-path) (timestamp src-file))
+      (nio/create-parent-directories new-path)
       (nio/copy-file src-file new-path))))

--- a/src/pinaclj/page.clj
+++ b/src/pinaclj/page.clj
@@ -39,6 +39,18 @@
      (not= :parent k)
      (retrieve-parent-value page opts k))))
 
+(declare contains-key?)
+
+(defn- contains-parent-key? [page opts k]
+  (when-let [linked-url (retrieve-value page :parent)]
+    (when-let [linked-page (get (:all-pages opts) linked-url)]
+      (contains-key? linked-page k (without-page opts linked-url)))))
+
+(defn contains-key? [page k opts]
+  (or (contains-in? page [:funcs k])
+      (contains? page k)
+      (and (not= :parent k) (contains-parent-key? page opts k))))
+
 (def non-written-headers #{:read-headers :raw-content :path :funcs :src-root})
 
 (defn- header-keys [page]

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -23,15 +23,17 @@
            :read-headers (vec (keys headers))
            :raw-content content)))
 
+(def separator "---")
+
 (defn- separates-headers? [line]
-  (= line "---"))
+  (= line separator))
 
 (defn- split-header-content [all-lines]
   (let [split (split-with (complement separates-headers?) all-lines)]
     [(first split) (clojure.string/join "\n" (rest (second split)))]))
 
 (defn- contains-separator? [all-lines]
-  (some #{"---"} all-lines))
+  (some #{separator} all-lines))
 
 (defn read-page [page]
   (let [all-lines (files/read-lines (:path page))]

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -3,6 +3,9 @@
             [pinaclj.nio :as nio]
             [pinaclj.date-time :as date-time]))
 
+(defn- contains-title? [headers]
+  (contains? headers :title))
+
 (defn- convert [[k v]]
   (if (= :published-at k)
     [k (date-time/from-str v)]
@@ -19,9 +22,11 @@
 
 (defn- merge-page [page [header content]]
   (let [headers (to-headers header)]
-    (assoc (merge page headers)
+    (if (contains-title? headers)
+      (assoc (merge page headers)
            :read-headers (vec (keys headers))
-           :raw-content content)))
+           :raw-content content)
+      {:result :invalid-source-file :errors [:no-title]})))
 
 (def separator "---")
 

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -3,23 +3,16 @@
             [pinaclj.nio :as nio]
             [pinaclj.date-time :as date-time]))
 
-(defn- separates-headers? [line]
-  (= line "---"))
+(defn- convert [[k v]]
+  (if (= :published-at k)
+    [k (date-time/from-str v)]
+    [k v]))
 
 (defn- to-header [line]
   (let [split-pos (.indexOf line ": ")]
     (when-not (= -1 split-pos)
        [(keyword (subs line 0 split-pos))
         (subs line (+ 2 split-pos))])))
-
-(defn- split-header-content [all-lines]
-  (let [split (split-with (complement separates-headers?) all-lines)]
-    [(first split) (clojure.string/join "\n" (rest (second split)))]))
-
-(defn- convert [[k v]]
-  (if (= :published-at k)
-    [k (date-time/from-str v)]
-    [k v]))
 
 (defn- to-headers [header-section]
   (into {} (map (comp convert to-header) header-section)))
@@ -30,5 +23,19 @@
            :read-headers (vec (keys headers))
            :raw-content content)))
 
+(defn- separates-headers? [line]
+  (= line "---"))
+
+(defn- split-header-content [all-lines]
+  (let [split (split-with (complement separates-headers?) all-lines)]
+    [(first split) (clojure.string/join "\n" (rest (second split)))]))
+
+(defn- contains-separator? [all-lines]
+  (some #{"---"} all-lines))
+
 (defn read-page [page]
-  (merge-page page (split-header-content (files/read-lines (:path page)))))
+  (let [all-lines (files/read-lines (:path page))]
+    (cond
+      (contains-separator? all-lines)
+      (merge-page page (split-header-content all-lines))
+      :else {:result :invalid-source-file})))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -4,7 +4,7 @@
             [pinaclj.date-time :as date-time]))
 
 (defn- invalid-source-file [error]
-  {:result :invalid-source-file :errors [error]})
+  {:issues [[:error error]]})
 
 (defn- contains-title? [headers]
   (contains? headers :title))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -3,6 +3,9 @@
             [pinaclj.nio :as nio]
             [pinaclj.date-time :as date-time]))
 
+(defn- invalid-source-file [error]
+  {:result :invalid-source-file :errors [error]})
+
 (defn- contains-title? [headers]
   (contains? headers :title))
 
@@ -26,7 +29,7 @@
       (assoc (merge page headers)
            :read-headers (vec (keys headers))
            :raw-content content)
-      {:result :invalid-source-file :errors [:no-title]})))
+      (invalid-source-file :no-title))))
 
 (def separator "---")
 
@@ -45,4 +48,4 @@
     (cond
       (contains-separator? all-lines)
       (merge-page page (split-header-content all-lines))
-      :else {:result :invalid-source-file :errors [:no-separator]})))
+      :else (invalid-source-file :no-separator))))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -40,4 +40,4 @@
     (cond
       (contains-separator? all-lines)
       (merge-page page (split-header-content all-lines))
-      :else {:result :invalid-source-file})))
+      :else {:result :invalid-source-file :errors [:no-separator]})))

--- a/src/pinaclj/read.clj
+++ b/src/pinaclj/read.clj
@@ -25,11 +25,11 @@
 
 (def separator "---")
 
-(defn- separates-headers? [line]
+(defn- line-is-separator? [line]
   (= line separator))
 
 (defn- split-header-content [all-lines]
-  (let [split (split-with (complement separates-headers?) all-lines)]
+  (let [split (split-with (complement line-is-separator?) all-lines)]
     [(first split) (clojure.string/join "\n" (rest (second split)))]))
 
 (defn- contains-separator? [all-lines]

--- a/src/pinaclj/site.clj
+++ b/src/pinaclj/site.clj
@@ -44,9 +44,15 @@
 (defn- update-all [m update-fn & args]
   (zipmap (keys m) (map #(apply update-fn % args) (vals m))))
 
+(defn- missing-fields-warning [page all-pages]
+  (let [missing-fields (filter #(not (page/contains-key? page % all-pages)) (get-in page [:template :data-ids]))]
+    (when (seq missing-fields)
+      [:warning :missing-fields missing-fields])))
+
 (defn- render-page [page all-pages]
-  (page/retrieve-value page :templated-content {:template (:template page)
-                                                :all-pages all-pages}))
+  {:content (page/retrieve-value page :templated-content {:template (:template page)
+                                                          :all-pages all-pages})
+   :issues (remove nil? [(missing-fields-warning page all-pages)])})
 
 (defn- render-pages [pages]
   (update-all pages render-page pages))

--- a/src/pinaclj/tasks/generate.clj
+++ b/src/pinaclj/tasks/generate.clj
@@ -15,7 +15,7 @@
 (defn- dest-last-modified [dest]
   (files/timestamp (nio/resolve-path dest index-page)))
 
-(defn- write-page [dest-root [page-path content]]
+(defn- write-page [dest-root [page-path {content :content}]]
   (files/create (nio/resolve-path dest-root page-path) content)
   (task/success (t :en :published-page page-path)))
 

--- a/src/pinaclj/tasks/publish.clj
+++ b/src/pinaclj/tasks/publish.clj
@@ -25,10 +25,15 @@
     (task/error (t :en :already-published (:path page)))
     (add-header src-root page time-fn)))
 
+(defn- read-validation [src-root page time-fn src-path]
+  (if (= :invalid-source-file (:result page))
+    (task/fatal (t :en (:errors page) src-path))
+    (publish-if-required src-root page time-fn)))
+
 (defn- publish-path [src-root src-path time-fn]
   (let [path (files/resolve-path src-root src-path)]
     (if (files/exists? path)
-      (publish-if-required src-root (read-page src-root path) time-fn)
+      (read-validation src-root (read-page src-root path) time-fn src-path)
       (task/error (t :en :not-found src-path)))))
 
 (defn publish [src-root src-paths time-fn]

--- a/src/pinaclj/tasks/task.clj
+++ b/src/pinaclj/tasks/task.clj
@@ -9,3 +9,6 @@
 
 (defn error [msg]
   {:type :error :msg msg})
+
+(defn fatal [msg]
+  {:type :fatal :msg msg})

--- a/src/pinaclj/test_fs.clj
+++ b/src/pinaclj/test_fs.clj
@@ -1,7 +1,6 @@
 (ns pinaclj.test-fs
   (:require [pinaclj.files :as files]
-            [pinaclj.nio :as nio]
-            [pinaclj.templates :as templates])
+            [pinaclj.nio :as nio])
   (:import (com.google.common.jimfs Jimfs Configuration)))
 
 (defn test-fs []

--- a/src/pinaclj/transforms/page_list.clj
+++ b/src/pinaclj/transforms/page_list.clj
@@ -16,7 +16,7 @@
 
 (defn- apply-max-pages [pages opts]
   (if-let [max-pages (max-pages opts)]
-    (subvec (vec pages) 0 max-pages)
+    (subvec (vec pages) 0 (min max-pages (count pages)))
     pages))
 
 (defn clone-pages [page-set opts]


### PR DESCRIPTION
This introduces a :fatal type, produces an error in read if a separator isn't present in a post or if there is no 'title' header, captures the error in publish, and spits the message out on screen instead of it spewing out the stack trace
